### PR TITLE
Add ellipsis operator to grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -495,17 +495,17 @@ module.exports = grammar(Python, {
 
     c_parameters: $ => seq("(", optional($._typedargslist), ")"),
     _typedargslist: $ =>
-    choice(
-      "...",
-      seq(
-        commaSep1(seq(
-          $.maybe_typed_name,
-          optional(seq(":", $.c_type)),
-          optional(seq("=", choice($.expression, "*"))),
-        )),
-        optional(","),
-      )
-    ),
+      choice(
+        "...",
+        seq(
+          commaSep1(seq(
+            $.maybe_typed_name,
+            optional(seq(":", $.c_type)),
+            optional(seq("=", choice($.expression, "*"))),
+          )),
+          optional(","),
+        ),
+      ),
 
     gil_spec: _ => choice(seq("with", choice("gil", "nogil")), "nogil"),
     exception_value: $ =>

--- a/grammar.js
+++ b/grammar.js
@@ -495,6 +495,8 @@ module.exports = grammar(Python, {
 
     c_parameters: $ => seq("(", optional($._typedargslist), ")"),
     _typedargslist: $ =>
+    choice(
+      "...",
       seq(
         commaSep1(seq(
           $.maybe_typed_name,
@@ -502,7 +504,8 @@ module.exports = grammar(Python, {
           optional(seq("=", choice($.expression, "*"))),
         )),
         optional(","),
-      ),
+      )
+    ),
 
     gil_spec: _ => choice(seq("with", choice("gil", "nogil")), "nogil"),
     exception_value: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8529,8 +8529,12 @@
       ]
     },
     "_typedargslist": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
+        {
+          "type": "STRING",
+          "value": "..."
+        },
         {
           "type": "SEQ",
           "members": [
@@ -8538,145 +8542,150 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "maybe_typed_name"
-                },
-                {
-                  "type": "CHOICE",
+                  "type": "SEQ",
                   "members": [
                     {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "c_type"
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "maybe_typed_name"
                     },
                     {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
+                      "type": "CHOICE",
                       "members": [
                         {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "CHOICE",
+                          "type": "SEQ",
                           "members": [
                             {
-                              "type": "SYMBOL",
-                              "name": "expression"
+                              "type": "STRING",
+                              "value": ":"
                             },
                             {
-                              "type": "STRING",
-                              "value": "*"
+                              "type": "SYMBOL",
+                              "name": "c_type"
                             }
                           ]
+                        },
+                        {
+                          "type": "BLANK"
                         }
                       ]
                     },
                     {
-                      "type": "BLANK"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "="
+                            },
+                            {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "expression"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "*"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
                     "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "maybe_typed_name"
+                        "type": "STRING",
+                        "value": ","
                       },
                       {
-                        "type": "CHOICE",
+                        "type": "SEQ",
                         "members": [
                           {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ":"
-                              },
-                              {
-                                "type": "SYMBOL",
-                                "name": "c_type"
-                              }
-                            ]
+                            "type": "SYMBOL",
+                            "name": "maybe_typed_name"
                           },
                           {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
+                            "type": "CHOICE",
                             "members": [
                               {
-                                "type": "STRING",
-                                "value": "="
-                              },
-                              {
-                                "type": "CHOICE",
+                                "type": "SEQ",
                                 "members": [
                                   {
-                                    "type": "SYMBOL",
-                                    "name": "expression"
+                                    "type": "STRING",
+                                    "value": ":"
                                   },
                                   {
-                                    "type": "STRING",
-                                    "value": "*"
+                                    "type": "SYMBOL",
+                                    "name": "c_type"
                                   }
                                 ]
+                              },
+                              {
+                                "type": "BLANK"
                               }
                             ]
                           },
                           {
-                            "type": "BLANK"
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "="
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "expression"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "*"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
                           }
                         ]
                       }
                     ]
                   }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": ","
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1930,6 +1930,11 @@
     }
   },
   {
+    "type": "ellipsis",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "else_clause",
     "named": true,
     "fields": {
@@ -4354,6 +4359,10 @@
     "named": false
   },
   {
+    "type": "...",
+    "named": false
+  },
+  {
     "type": "/",
     "named": false
   },
@@ -4604,10 +4613,6 @@
   {
     "type": "elif",
     "named": false
-  },
-  {
-    "type": "ellipsis",
-    "named": true
   },
   {
     "type": "else",

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -587,3 +587,25 @@ cdef numeric add(numeric a, numeric b)
           (maybe_typed_name
             (identifier)
             (identifier)))))))
+
+================================================================================
+Cython ellipsis function
+================================================================================
+
+cdef cppclass Test:
+    int func(...)
+
+--------------------------------------------------------------------------------
+
+(module
+  (cdef_statement
+    (cdef_type_declaration
+      (ctype_declaration
+        (cppclass
+          (identifier)
+          (cvar_def
+            (maybe_typed_name
+              (int_type)
+              (identifier))
+            (c_function_definition
+              (c_parameters))))))))


### PR DESCRIPTION
Hello,

I am excited about this project and its potential to improve the tooling around cython. I tried to get my hands dirty by adding support for the ellipsis in functions, which is present in `any.pxd` (among others):

```
cdef cppclass any:
    % ...
    T& emplace[T](...) except +
    % ...
```

As far as I can tell this decreases the number of parse errors from 174 to 172.
