### PR TITLE
Add support for typedefs internal to cppclasses

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -622,6 +622,7 @@ module.exports = grammar(Python, {
         seq(
           $._indent,
           repeat(choice(
+            $.ctypedef_statement,
             $.cvar_def,
             $.cppclass,
           )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9167,6 +9167,10 @@
                 "members": [
                   {
                     "type": "SYMBOL",
+                    "name": "ctypedef_statement"
+                  },
+                  {
+                    "type": "SYMBOL",
                     "name": "cvar_def"
                   },
                   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1416,6 +1416,10 @@
           "named": true
         },
         {
+          "type": "ctypedef_statement",
+          "named": true
+        },
+        {
           "type": "cvar_def",
           "named": true
         },

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -958,3 +958,24 @@ ctypedef class SimpleClass:
             (maybe_typed_name
               (int_type)
               (identifier))))))))
+
+=====================================
+Class with internal typedef
+=====================================
+cdef cppclass Example[T]:
+    ctypedef T LocalAlias
+---
+
+(module
+  (cdef_statement
+    (cdef_type_declaration
+      (ctype_declaration
+        (cppclass
+          (identifier)
+          (template_params
+            (identifier))
+          (ctypedef_statement
+            (cvar_decl
+              (c_type
+                (identifier))
+              (identifier))))))))


### PR DESCRIPTION
This should enable class-internal typedefs:

```
cdef cppclass Example[T]:
    ctypedef T LocalAlias
```

As an aside: The repository contains several auto-generated files (`src/parser.c`, `src/node-types.json`, `src/grammar.json`) which make for large diffs. Could these by any chance be removed?