### PR TITLE
Add support for default template arguments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -470,10 +470,16 @@ module.exports = grammar(Python, {
         ),
       ),
 
+    template_default: $ =>
+      seq("=", "*"),
+
+    template_param: $ =>
+      seq($.identifier, optional($.template_default)),
+
     template_params: $ =>
       seq(
         "[",
-        commaSep1($.identifier),
+        commaSep1($.template_param),
         "]",
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8500,6 +8500,40 @@
         }
       ]
     },
+    "template_default": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        }
+      ]
+    },
+    "template_param": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "template_default"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "template_params": {
       "type": "SEQ",
       "members": [
@@ -8512,7 +8546,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "template_param"
             },
             {
               "type": "REPEAT",
@@ -8525,7 +8559,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "template_param"
                   }
                 ]
               }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3732,7 +3732,12 @@
     }
   },
   {
-    "type": "template_params",
+    "type": "template_default",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "template_param",
     "named": true,
     "fields": {},
     "children": {
@@ -3741,6 +3746,25 @@
       "types": [
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "template_default",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "template_params",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "template_param",
           "named": true
         }
       ]

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -973,9 +973,35 @@ cdef cppclass Example[T]:
         (cppclass
           (identifier)
           (template_params
-            (identifier))
+            (template_param
+              (identifier)))
           (ctypedef_statement
             (cvar_decl
               (c_type
                 (identifier))
+              (identifier))))))))
+
+=====================================
+Class with default template params
+=====================================
+cdef cppclass SomeClass[U, V, W=*]:
+    pass
+---
+
+(module
+  (cdef_statement
+    (cdef_type_declaration
+      (ctype_declaration
+        (cppclass
+          (identifier)
+          (template_params
+            (template_param
+              (identifier))
+            (template_param
+              (identifier))
+            (template_param
+              (identifier)
+              (template_default)))
+          (cvar_def
+            (maybe_typed_name
               (identifier))))))))


### PR DESCRIPTION
Example:

```
cdef cppclass SomeClass[U, V, W=*]:
    pass
```
