### PR TITLE
Add support for declarations of variables of "function pointer" type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -396,7 +396,7 @@ module.exports = grammar(Python, {
             optional("complex"),
             repeat($.type_qualifier),
           )),
-          field("name", optional(choice($.identifier, $.operator_name))),
+          field("name", optional(choice($.identifier, $.operator_name, $.c_function_pointer_name))),
           repeat($.type_qualifier),
         ),
         seq(
@@ -405,6 +405,9 @@ module.exports = grammar(Python, {
           repeat($.type_qualifier),
         ),
       ),
+
+    c_function_pointer_name: $ =>
+      seq("(", "*", field("name", $.identifier), ")"),
 
     // type_qualifier: '*' | '**' | '&' | type_index ('.' NAME [type_index])*
     type_qualifier: $ =>

--- a/grammar.js
+++ b/grammar.js
@@ -686,7 +686,7 @@ module.exports = grammar(Python, {
         seq(
           "sizeof",
           "(",
-          $.c_type,
+          choice($.c_type, $.expression),
           ")",
         ),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -164,15 +164,18 @@ module.exports = grammar(Python, {
           $.cvar_def,
           $.cdef_type_declaration,
           $.extern_block,
-          seq(
-            repeat($.storageclass),
-            optional(choice($.identifier, $.keyword_identifier)),
-            ":",
-            $._indent,
-            repeat1(choice($.cvar_def, $.ctypedef_statement, $.cdef_type_declaration, $.extern_block)),
-            $._dedent,
-          ),
+          $.cdef_definition_block,
         ),
+      ),
+
+    cdef_definition_block: $ =>
+      seq(
+        repeat($.storageclass),
+        optional(choice($.identifier, $.keyword_identifier)),
+        ":",
+        $._indent,
+        repeat1(choice($.cvar_def, $.ctypedef_statement, $.cdef_type_declaration, $.extern_block)),
+        $._dedent,
       ),
 
     cvar_def: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6700,75 +6700,79 @@
               "name": "extern_block"
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "storageclass"
-                  }
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "identifier"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "keyword_identifier"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": ":"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_indent"
-                },
-                {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "cvar_def"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "ctypedef_statement"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "cdef_type_declaration"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "extern_block"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_dedent"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "cdef_definition_block"
             }
           ]
+        }
+      ]
+    },
+    "cdef_definition_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "storageclass"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_identifier"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "cvar_def"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "ctypedef_statement"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "cdef_type_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "extern_block"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8001,6 +8001,10 @@
                       {
                         "type": "SYMBOL",
                         "name": "operator_name"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "c_function_pointer_name"
                       }
                     ]
                   },
@@ -8068,6 +8072,31 @@
               }
             }
           ]
+        }
+      ]
+    },
+    "c_function_pointer_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9357,8 +9357,17 @@
             "value": "("
           },
           {
-            "type": "SYMBOL",
-            "name": "c_type"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "c_type"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              }
+            ]
           },
           {
             "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -865,6 +865,22 @@
     }
   },
   {
+    "type": "c_function_pointer_name",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "c_name",
     "named": true,
     "fields": {},
@@ -3067,6 +3083,10 @@
         "multiple": false,
         "required": false,
         "types": [
+          {
+            "type": "c_function_pointer_name",
+            "named": true
+          },
           {
             "type": "identifier",
             "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1113,7 +1113,7 @@
     }
   },
   {
-    "type": "cdef_statement",
+    "type": "cdef_definition_block",
     "named": true,
     "fields": {},
     "children": {
@@ -1142,6 +1142,33 @@
         },
         {
           "type": "storageclass",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "cdef_statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "cdef_definition_block",
+          "named": true
+        },
+        {
+          "type": "cdef_type_declaration",
+          "named": true
+        },
+        {
+          "type": "cvar_def",
+          "named": true
+        },
+        {
+          "type": "extern_block",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3591,6 +3591,10 @@
         {
           "type": "c_type",
           "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
         }
       ]
     }

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -274,34 +274,35 @@ cdef ullong factorial(int n):
 
 (module
   (cdef_statement
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (identifier)))
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (identifier)))
-    (cvar_def
-      (maybe_typed_name
-        (identifier)
-        (identifier)))
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (type_qualifier)
-        (identifier)))
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (type_qualifier
-          (type_index
-            (memory_view_index)))
-        (identifier)))
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (identifier))))
+    (cdef_definition_block
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (identifier)))
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (identifier)))
+      (cvar_def
+        (maybe_typed_name
+          (identifier)
+          (identifier)))
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (type_qualifier)
+          (identifier)))
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (type_qualifier
+            (type_index
+              (memory_view_index)))
+          (identifier)))
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (identifier)))))
   (ctypedef_statement
     (cvar_decl
       (c_type
@@ -475,14 +476,15 @@ cdef numeric add(numeric a, numeric b)
         (identifier)
         (block
           (cdef_statement
-            (cvar_def
-              (maybe_typed_name
-                (int_type)
-                (identifier)))
-            (cvar_def
-              (maybe_typed_name
-                (int_type)
-                (identifier))))
+            (cdef_definition_block
+              (cvar_def
+                (maybe_typed_name
+                  (int_type)
+                  (identifier)))
+              (cvar_def
+                (maybe_typed_name
+                  (int_type)
+                  (identifier)))))
           (cdef_statement
             (cvar_def
               (maybe_typed_name
@@ -697,33 +699,34 @@ cdef:
 
 (module
   (cdef_statement
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (identifier))
-      (c_function_definition
-        (c_parameters
-          (maybe_typed_name
-            (int_type)
-            (identifier)))))
-    (cvar_def
-      (maybe_typed_name
-        (identifier)
-        (identifier))
-      (c_function_definition
-        (c_parameters)))
-    (cvar_def
-      (maybe_typed_name
-        (int_type)
-        (identifier))
-      (c_function_definition
-        (c_parameters
-          (maybe_typed_name
-            (int_type)
-            (identifier))
-          (maybe_typed_name
-            (int_type)
-            (identifier)))))))
+    (cdef_definition_block
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (identifier))
+        (c_function_definition
+          (c_parameters
+            (maybe_typed_name
+              (int_type)
+              (identifier)))))
+      (cvar_def
+        (maybe_typed_name
+          (identifier)
+          (identifier))
+        (c_function_definition
+          (c_parameters)))
+      (cvar_def
+        (maybe_typed_name
+          (int_type)
+          (identifier))
+        (c_function_definition
+          (c_parameters
+            (maybe_typed_name
+              (int_type)
+              (identifier))
+            (maybe_typed_name
+              (int_type)
+              (identifier))))))))
 
 =====================================
 Variadic function with modifiers

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -1008,3 +1008,23 @@ cdef cppclass SomeClass[U, V, W=*]:
           (cvar_def
             (maybe_typed_name
               (identifier))))))))
+
+=====================================
+Declaration of a C function pointer variable
+=====================================
+cdef const int (*pfunc_add)(const char*, int)
+---
+(module
+  (cdef_statement
+    (cvar_def
+      (maybe_typed_name
+        (int_type)
+        (c_function_pointer_name
+          (identifier)))
+      (c_function_definition
+        (c_parameters
+          (maybe_typed_name
+            (int_type)
+            (type_qualifier))
+          (maybe_typed_name
+            (int_type)))))))

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -1028,3 +1028,9 @@ cdef const int (*pfunc_add)(const char*, int)
             (type_qualifier))
           (maybe_typed_name
             (int_type)))))))
+=====================================
+sizeof() with expression argument
+=====================================
+cdef int i, j, k
+i = sizeof(j + k)
+--


### PR DESCRIPTION
This should add support for cdef statements like

```
cdef const int (*pfunc_add)(const char*, int)
```

and brings the number of errors down to 145. I am a bit uncertain regarding the usage of the "field" function. Is this as intended in the "c_function_pointer_name" rule?