### PR TITLE
Add support for "for-from loops" with "by" argument

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -129,7 +129,8 @@ module.exports = grammar(Python, {
     _compound_statement: ($, original) =>
       choice(
         original,
-        $.def_statement,
+        $.DEF_statement,
+        $.IF_statement,
         $.cdef_statement,
         $.ctypedef_statement,
         $.property_definition,
@@ -148,7 +149,7 @@ module.exports = grammar(Python, {
         ),
       ),
 
-    def_statement: $ =>
+    DEF_statement: $ =>
       seq(
         "DEF",
         field("name", $.identifier),
@@ -156,6 +157,28 @@ module.exports = grammar(Python, {
         $.expression,
         $._newline,
       ),
+
+    IF_statement: $ => seq(
+      "IF",
+      field("condition", $.expression),
+      ":",
+      field("consequence", $._suite),
+      repeat(field("alternative", $.ELIF_clause)),
+      optional(field("alternative", $.ELSE_clause)),
+    ),
+
+    ELIF_clause: $ => seq(
+      "ELIF",
+      field("condition", $.expression),
+      ":",
+      field("consequence", $._suite),
+    ),
+
+    ELSE_clause: $ => seq(
+      "ELSE",
+      ":",
+      field("body", $._suite),
+    ),
 
     cdef_statement: $ =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -729,6 +729,10 @@ module.exports = grammar(Python, {
           choice("in", "from"),
         )),
         field("right", $._expressions),
+        optional(seq(
+          "by",
+          $._expressions,
+        )),
         ":",
         field("body", $._suite),
         field("alternative", optional($.else_clause)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -851,7 +851,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "def_statement"
+          "name": "DEF_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "IF_statement"
         },
         {
           "type": "SYMBOL",
@@ -6660,7 +6664,7 @@
         }
       ]
     },
-    "def_statement": {
+    "DEF_statement": {
       "type": "SEQ",
       "members": [
         {
@@ -6686,6 +6690,112 @@
         {
           "type": "SYMBOL",
           "name": "_newline"
+        }
+      ]
+    },
+    "IF_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "IF"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "consequence",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_suite"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ELIF_clause"
+            }
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "alternative",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ELSE_clause"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "ELIF_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ELIF"
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "consequence",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_suite"
+          }
+        }
+      ]
+    },
+    "ELSE_clause": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ELSE"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_suite"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1213,6 +1213,27 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "by"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expressions"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": ":"
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4,6 +4,14 @@
     "named": true,
     "subtypes": [
       {
+        "type": "DEF_statement",
+        "named": true
+      },
+      {
+        "type": "IF_statement",
+        "named": true
+      },
+      {
         "type": "cdef_statement",
         "named": true
       },
@@ -17,10 +25,6 @@
       },
       {
         "type": "decorated_definition",
-        "named": true
-      },
-      {
-        "type": "def_statement",
         "named": true
       },
       {
@@ -358,6 +362,114 @@
         "named": true
       }
     ]
+  },
+  {
+    "type": "DEF_statement",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "ELIF_clause",
+    "named": true,
+    "fields": {
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "consequence": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "ELSE_clause",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "IF_statement",
+    "named": true,
+    "fields": {
+      "alternative": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "ELIF_clause",
+            "named": true
+          },
+          {
+            "type": "ELSE_clause",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "consequence": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "aliased_import",
@@ -1689,32 +1801,6 @@
     "type": "decorator",
     "named": true,
     "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "def_statement",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      }
-    },
     "children": {
       "multiple": false,
       "required": true,
@@ -4576,6 +4662,18 @@
   },
   {
     "type": "DEF",
+    "named": false
+  },
+  {
+    "type": "ELIF",
+    "named": false
+  },
+  {
+    "type": "ELSE",
+    "named": false
+  },
+  {
+    "type": "IF",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2358,6 +2358,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "expression_list",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -4646,6 +4660,10 @@
   },
   {
     "type": "break",
+    "named": false
+  },
+  {
+    "type": "by",
     "named": false
   },
   {

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -1101,3 +1101,23 @@ cdef extern from *:
                     (int_type))
                   (maybe_typed_name
                     (int_type)))))))))))
+=====================================
+For-from loop with "by" argument
+=====================================
+for i from 0 <= i < 10 by 2:
+    print(i)
+---
+(module
+  (for_statement
+    (identifier)
+    (comparison_operator
+      (integer)
+      (identifier)
+      (integer))
+    (integer)
+    (block
+      (expression_statement
+        (call
+          (identifier)
+          (argument_list
+            (identifier)))))))

--- a/test/corpus/cython.txt
+++ b/test/corpus/cython.txt
@@ -1121,3 +1121,34 @@ for i from 0 <= i < 10 by 2:
           (identifier)
           (argument_list
             (identifier)))))))
+=====================================
+IF statement
+=====================================
+IF True:
+    pass
+ELIF False:
+    pass
+ELSE:
+    pass
+---
+(module
+  (IF_statement
+    (true)
+    (block
+      (pass_statement))
+    (ELIF_clause
+      (false)
+      (block
+        (pass_statement)))
+    (ELSE_clause
+      (block
+        (pass_statement)))))
+=====================================
+DEF statement
+=====================================
+DEF x = 1
+---
+(module
+  (DEF_statement
+    (identifier)
+    (integer)))


### PR DESCRIPTION
The (slightly cursed) syntax is "for i from 0 <= i < 10:",

I also snuck in support for "IF" statements (i.e., C compiler "#if"s)

