### PR TITLE
Extend support for integer literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -48,6 +48,43 @@ module.exports = grammar(Python, {
 
     run_directive: $ => seq("PYTHON", /[^\r\n]+/, $._newline),
 
+    c_integer_signedness: $ =>
+      /[uU]/,
+
+    c_integer_type: $ => choice(
+      seq(
+        optional($.c_integer_signedness),
+        /[lL]/,
+        optional(/[lL]/),
+      ),
+      $.c_integer_signedness,
+    ),
+
+    integer: $ => choice(
+      seq(
+        choice("0x", "0X"),
+        repeat1(/_?[A-Fa-f0-9]+/),
+        optional($.c_integer_type),
+      ),
+      seq(
+        choice("0o", "0O"),
+        repeat1(/_?[0-7]+/),
+        optional($.c_integer_type),
+      ),
+      seq(
+        choice("0b", "0B"),
+        repeat1(/_?[0-1]+/),
+        optional($.c_integer_type),
+      ),
+      seq(
+        repeat1(/[0-9]+_?/),
+        choice(
+          optional($.c_integer_type), // long numbers
+          optional(/[jJ]/), // complex numbers
+        ),
+      ),
+    ),
+
     // Cython allows 'cimport'
     import_statement: $ =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6063,164 +6063,161 @@
       "value": "![a-z]"
     },
     "integer": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "0x"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "0X"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "_?[A-Fa-f0-9]+"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "0x"
+                },
+                {
+                  "type": "STRING",
+                  "value": "0X"
                 }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[Ll]"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "PATTERN",
+                "value": "_?[A-Fa-f0-9]+"
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "0o"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "0O"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "_?[0-7]+"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "c_integer_type"
+                },
+                {
+                  "type": "BLANK"
                 }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[Ll]"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "0b"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "0B"
-                  }
-                ]
-              },
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "_?[0-1]+"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "0o"
+                },
+                {
+                  "type": "STRING",
+                  "value": "0O"
                 }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[Ll]"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "PATTERN",
+                "value": "_?[0-7]+"
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[0-9]+_?"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "c_integer_type"
+                },
+                {
+                  "type": "BLANK"
                 }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[Ll]"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[jJ]"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "0b"
+                },
+                {
+                  "type": "STRING",
+                  "value": "0B"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "PATTERN",
+                "value": "_?[0-1]+"
               }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "c_integer_type"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "PATTERN",
+                "value": "[0-9]+_?"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "c_integer_type"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[jJ]"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     "float": {
       "type": "TOKEN",
@@ -6536,6 +6533,52 @@
         {
           "type": "SYMBOL",
           "name": "_newline"
+        }
+      ]
+    },
+    "c_integer_signedness": {
+      "type": "PATTERN",
+      "value": "[uU]"
+    },
+    "c_integer_type": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "c_integer_signedness"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "PATTERN",
+              "value": "[lL]"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[lL]"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "c_integer_signedness"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1012,6 +1012,21 @@
     }
   },
   {
+    "type": "c_integer_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "c_integer_signedness",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "c_name",
     "named": true,
     "fields": {},
@@ -2847,6 +2862,21 @@
     "fields": {}
   },
   {
+    "type": "integer",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "c_integer_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "interpolation",
     "named": true,
     "fields": {
@@ -4593,6 +4623,30 @@
     "named": false
   },
   {
+    "type": "0B",
+    "named": false
+  },
+  {
+    "type": "0O",
+    "named": false
+  },
+  {
+    "type": "0X",
+    "named": false
+  },
+  {
+    "type": "0b",
+    "named": false
+  },
+  {
+    "type": "0o",
+    "named": false
+  },
+  {
+    "type": "0x",
+    "named": false
+  },
+  {
     "type": ":",
     "named": false
   },
@@ -4769,6 +4823,10 @@
     "named": false
   },
   {
+    "type": "c_integer_signedness",
+    "named": true
+  },
+  {
     "type": "case",
     "named": false
   },
@@ -4935,10 +4993,6 @@
   {
     "type": "int",
     "named": false
-  },
-  {
-    "type": "integer",
-    "named": true
   },
   {
     "type": "is",

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -16,6 +16,23 @@ Integers
 0O1_1
 0L
 
+1_0
+1_0L
+1_0LL
+1_0UL
+10ULL
+
+1_0l
+1_0ll
+1_0ul
+10ull
+
+1_0l
+1_0lL
+10ulL
+
+1_0u
+
 --------------------------------------------------------------------------------
 
 (module
@@ -46,7 +63,52 @@ Integers
   (expression_statement
     (integer))
   (expression_statement
-    (integer)))
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness))))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness))))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness))))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness))))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type)))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness))))
+  (expression_statement
+    (integer
+      (c_integer_type
+        (c_integer_signedness)))))
 
 ================================================================================
 Floats


### PR DESCRIPTION
Integer literals can include signedness, i.e., `123ULL`.

Edit: Discarding the expression-based array sizes for now...