### PR TITLE
Add `.pxi` to supported file types

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -7,7 +7,8 @@
       "path": ".",
       "file-types": [
         "pyx",
-        "pxd"
+        "pxd",
+        "pxi"
       ],
       "highlights": "queries/highlights.scm",
       "injections": "queries/injections.scm",


### PR DESCRIPTION
This adds support for [Cython include files](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#cython-file-types).