### PR TITLE
Add outline query

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -62,6 +62,9 @@ pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 /// The symbol tagging query for this language.
 pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 
+/// The outline query for this language.
+pub const OUTLINE_QUERY: &str = include_str!("../../queries/outline.scm");
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/queries/outline.scm
+++ b/queries/outline.scm
@@ -1,0 +1,18 @@
+(decorator) @annotation
+
+(class_definition
+    "class" @context
+    name: (identifier) @name
+    ) @item
+
+(function_definition
+    "async"? @context
+    "def" @context
+    name: (_) @name) @item
+
+(cdef_statement
+    ["cdef" "cpdef"] @context
+    (cvar_def
+        (maybe_typed_name
+            name: (_) @name)
+        (c_function_definition))) @item

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -12,7 +12,8 @@
       "highlights": "queries/highlights.scm",
       "injections": "queries/injections.scm",
       "locals": "queries/locals.scm",
-      "tags": "queries/tags.scm"
+      "tags": "queries/tags.scm",
+      "outline": "queries/outline.scm"
     }
   ],
   "metadata": {


### PR DESCRIPTION
This adds a query outline support.

I tested this in Zed via https://github.com/lgeiger/zed-cython:
<img width="582" alt="Screenshot 2024-12-14 at 18 06 01" src="https://github.com/user-attachments/assets/11e852b9-8f58-4426-be02-8ed07cf9a29f" />
